### PR TITLE
Compat with v2/v3 and fix test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ after_success:
   - coveralls
 notifications:
   email: false
+sudo: false

--- a/README.rst
+++ b/README.rst
@@ -3,10 +3,16 @@ pypuppetdb
 ##########
 
 .. image:: https://api.travis-ci.org/puppet-community/pypuppetdb.png
-   :target: https://travis-ci.org/puppet-communit/pypuppetdb
+   :target: https://travis-ci.org/puppet-community/pypuppetdb
 
 .. image:: https://coveralls.io/repos/puppet-community/pypuppetdb/badge.png
-   :target: https://coeralls.io/r/puppet-community/pypuppetdb
+   :target: https://coveralls.io/repos/puppet-community/pypuppetdb
+
+
+.. image:: https://travis-ci.org/colmat/pypuppetdb.svg?branch=work-pdb3
+    :target: https://travis-ci.org/colmat/pypuppetdb
+
+.. image:: https://coveralls.io/repos/colmat/pypuppetdb/badge.svg?branch=work-pdb3&service=github :target: https://coveralls.io/github/colmat/pypuppetdb?branch=work-pdb3
 
 pypuppetdtb is a library to work with PuppetDB's REST API. It is implemented
 using the `requests`_ library.
@@ -33,7 +39,7 @@ You can install this package from source or from PyPi.
 
 .. code-block:: bash
 
-   $ git clone https://github.com/nedap/pypuppetdb
+   $ git clone https://github.com/puppet-community/pypuppetdb
    $ python setup.py install
 
 If you wish to hack on it clone the repository but after that run:

--- a/README.rst
+++ b/README.rst
@@ -2,20 +2,16 @@
 pypuppetdb
 ##########
 
-.. image:: https://api.travis-ci.org/nedap/pypuppetdb.png
-   :target: https://travis-ci.org/nedap/pypuppetdb
+.. image:: https://api.travis-ci.org/puppet-community/pypuppetdb.png
+   :target: https://travis-ci.org/puppet-communit/pypuppetdb
 
-.. image:: https://coveralls.io/repos/nedap/pypuppetdb/badge.png
-   :target: https://coeralls.io/r/nedap/pypuppetdb
-
-.. image:: https://pypip.in/d/pypuppetdb/badge.png
-   :target: https://crate.io/packages/pypuppetdb
-
-.. image:: https://pypip.in/v/pypuppetdb/badge.png
-   :target: https://crate.io/packages/pypuppetdb
+.. image:: https://coveralls.io/repos/puppet-community/pypuppetdb/badge.png
+   :target: https://coeralls.io/r/puppet-community/pypuppetdb
 
 pypuppetdtb is a library to work with PuppetDB's REST API. It is implemented
 using the `requests`_ library.
+
+**pypuppetdb DOES NOT work with PuppetDB 3**
 
 .. _requests: http://docs.python-requests.org/en/latest/
 

--- a/README.rst
+++ b/README.rst
@@ -9,11 +9,6 @@ pypuppetdb
    :target: https://coveralls.io/repos/puppet-community/pypuppetdb
 
 
-.. image:: https://travis-ci.org/colmat/pypuppetdb.svg?branch=work-pdb3
-    :target: https://travis-ci.org/colmat/pypuppetdb
-
-.. image:: https://coveralls.io/repos/colmat/pypuppetdb/badge.svg?branch=work-pdb3&service=github :target: https://coveralls.io/github/colmat/pypuppetdb?branch=work-pdb3
-
 pypuppetdtb is a library to work with PuppetDB's REST API. It is implemented
 using the `requests`_ library.
 

--- a/conftest.py
+++ b/conftest.py
@@ -15,6 +15,12 @@ def api3():
     return pypuppetdb.connect(api_version=3)
 
 
+@pytest.fixture(scope='session')
+def api4():
+    """Set up a connection to PuppetDB with API version 4."""
+    return pypuppetdb.connect(api_version=4)
+
+
 @pytest.fixture
 def baseapi():
     return pypuppetdb.api.BaseAPI(3)

--- a/pypuppetdb/api/__init__.py
+++ b/pypuppetdb/api/__init__.py
@@ -11,7 +11,7 @@ from pypuppetdb.errors import (
     EmptyResponseError,
     UnsupportedVersionError,
     APIError,
-    )
+)
 
 log = logging.getLogger(__name__)
 
@@ -23,27 +23,27 @@ API_VERSIONS = {
 
 ENDPOINTS = {
     2: {
-        'facts': 'facts',
-        'fact-names': 'fact-names',
-        'nodes': 'nodes',
-        'resources': 'resources',
-        'metrics': 'metrics',
-        'mbean': 'metrics/mbean',
+        'facts': 'v2/facts',
+        'fact-names': 'v2/fact-names',
+        'nodes': 'v2/nodes',
+        'resources': 'v2/resources',
+        'metrics': 'v2/metrics',
+        'mbean': 'v2/metrics/mbean',
     },
     3: {
-        'facts': 'facts',
-        'fact-names': 'fact-names',
-        'nodes': 'nodes',
-        'resources': 'resources',
-        'catalogs': 'catalogs',
-        'metrics': 'metrics',
-        'mbean': 'metrics/mbean',
-        'reports': 'reports',
-        'events': 'events',
-        'event-counts': 'event-counts',
-        'aggregate-event-counts': 'aggregate-event-counts',
-        'server-time': 'server-time',
-        'version': 'version',
+        'facts': 'v3/facts',
+        'fact-names': 'v3/fact-names',
+        'nodes': 'v3/nodes',
+        'resources': 'v3/resources',
+        'catalogs': 'v3/catalogs',
+        'metrics': 'v3/metrics',
+        'mbean': 'v3/metrics/mbean',
+        'reports': 'v3/reports',
+        'events': 'v3/events',
+        'event-counts': 'v3/event-counts',
+        'aggregate-event-counts': 'v3/aggregate-event-counts',
+        'server-time': 'v3/server-time',
+        'version': 'v3/version',
     },
     4: {
         'facts': 'pdb/query/v4/facts',
@@ -206,7 +206,7 @@ class BaseAPI(object):
             host=self.host,
             port=self.port,
             url_path=self.url_path,
-            )
+        )
 
     @property
     def total(self):
@@ -259,7 +259,7 @@ class BaseAPI(object):
         url = '{base_url}/{endpoint}'.format(
             base_url=self.base_url,
             endpoint=endpoint,
-            )
+        )
 
         if path is not None:
             url = '{0}/{1}'.format(url, path)

--- a/pypuppetdb/api/__init__.py
+++ b/pypuppetdb/api/__init__.py
@@ -66,6 +66,33 @@ ENDPOINTS = {
     }
 }
 
+PARAMETERS = {
+    2: {
+        'order_by': 'order-by',
+        'include_total': 'include-total',
+        'count_by': 'count-by',
+        'counts_filter': 'counts-filter',
+        'summarize_by': 'summarize-by',
+        'server_time': 'server-time',
+    },
+    3: {
+        'order_by': 'order-by',
+        'include_total': 'include-total',
+        'count_by': 'count-by',
+        'counts_filter': 'counts-filter',
+        'summarize_by': 'summarize-by',
+        'server_time': 'server-time',
+    },
+    4: {
+        'order_by': 'order_by',
+        'include_total': 'include_total',
+        'count_by': 'count_by',
+        'counts_filter': 'counts_filter',
+        'summarize_by': 'summarize_by',
+        'server_time': 'server_time',
+    }
+}
+
 ERROR_STRINGS = {
     'timeout': 'Connection to PuppetDB timed out on',
     'refused': 'Could not reach PuppetDB on',
@@ -168,6 +195,7 @@ class BaseAPI(object):
             self.password = None
 
         self.endpoints = ENDPOINTS[api_version]
+        self.parameters = PARAMETERS[api_version]
         self._session = requests.Session()
         self._session.headers = {
             'content-type': 'application/json',
@@ -319,19 +347,19 @@ class BaseAPI(object):
         if query is not None:
             payload['query'] = query
         if order_by is not None:
-            payload['order-by'] = order_by
+            payload[self.parameters['order_by']] = order_by
         if limit is not None:
             payload['limit'] = limit
         if include_total is True:
-            payload['include-total'] = json.dumps(include_total)
+            payload[self.parameters['include_total']] = json.dumps(include_total)
         if offset is not None:
             payload['offset'] = offset
         if summarize_by is not None:
-            payload['summarize_by'] = summarize_by
+            payload[self.parameters['summarize_by']] = summarize_by
         if count_by is not None:
-            payload['count_by'] = count_by
+            payload[self.parameters['count_by']] = count_by
         if count_filter is not None:
-            payload['counts_filter'] = count_filter
+            payload[self.parameters['counts_filter']] = count_filter
 
         if not (payload):
             payload = None
@@ -422,7 +450,7 @@ class BaseAPI(object):
 
     def server_time(self):
         """Get the current time of the clock on the PuppetDB server"""
-        return self._query('server-time')['server_time']
+        return self._query('server-time')[self.parameters['server_time']]
 
     def current_version(self):
         """Get version information about the running PuppetDB server"""

--- a/pypuppetdb/api/__init__.py
+++ b/pypuppetdb/api/__init__.py
@@ -351,7 +351,8 @@ class BaseAPI(object):
         if limit is not None:
             payload['limit'] = limit
         if include_total is True:
-            payload[self.parameters['include_total']] = json.dumps(include_total)
+            payload[self.parameters['include_total']] = \
+                json.dumps(include_total)
         if offset is not None:
             payload['offset'] = offset
         if summarize_by is not None:

--- a/pypuppetdb/api/v4.py
+++ b/pypuppetdb/api/v4.py
@@ -110,6 +110,7 @@ class API(BaseAPI):
             yield Node(self,
                        node['certname'],
                        deactivated=node['deactivated'],
+                       expired=node['expired'],
                        report_timestamp=node['report_timestamp'],
                        catalog_timestamp=node['catalog_timestamp'],
                        facts_timestamp=node['facts_timestamp'],

--- a/pypuppetdb/api/v4.py
+++ b/pypuppetdb/api/v4.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from pypuppetdb.types import (
     Node, Fact, Resource,
     Report, Event, Catalog
-    )
+)
 
 log = logging.getLogger(__name__)
 
@@ -60,8 +60,10 @@ class API(BaseAPI):
             nodes = [nodes, ]
 
         if with_status:
-            latest_reports = self._query('reports',
-                query='["=","latest_report?",true]')
+            latest_reports = self._query(
+                'reports',
+                query='["=","latest_report?",true]'
+            )
 
         for node in nodes:
             node['unreported_time'] = None
@@ -86,15 +88,15 @@ class API(BaseAPI):
                     last_report = json_to_datetime(node['report_timestamp'])
                     last_report = last_report.replace(tzinfo=None)
                     now = datetime.utcnow()
-                    unreported_border = now-timedelta(hours=unreported)
+                    unreported_border = now - timedelta(hours=unreported)
                     if last_report < unreported_border:
-                        delta = (datetime.utcnow()-last_report)
+                        delta = (datetime.utcnow() - last_report)
                         node['status'] = 'unreported'
                         node['unreported_time'] = '{0}d {1}h {2}m'.format(
                             delta.days,
-                            int(delta.seconds/3600),
-                            int((delta.seconds % 3600)/60)
-                            )
+                            int(delta.seconds / 3600),
+                            int((delta.seconds % 3600) / 60)
+                        )
                 except AttributeError:
                     node['status'] = 'unreported'
 
@@ -139,7 +141,7 @@ class API(BaseAPI):
                 fact['name'],
                 fact['value'],
                 fact['environment']
-                )
+            )
 
     def resources(self, type_=None, title=None, query=None):
         """Query for resources limited by either type and/or title or query.
@@ -171,7 +173,7 @@ class API(BaseAPI):
                 sourceline=resource['line'],
                 parameters=resource['parameters'],
                 environment=resource['environment'],
-                )
+            )
 
     def reports(self, query):
         """Get reports for our infrastructure. Currently reports can only
@@ -197,7 +199,7 @@ class API(BaseAPI):
                 events_=report['resource_events'],
                 metrics_=report['metrics'],
                 logs_=report['logs']
-                )
+            )
 
     def events(self, query, order_by=None, limit=None):
         """A report is made up of events. This allows to query for events
@@ -222,7 +224,7 @@ class API(BaseAPI):
                 execution_path=event['containment_path'],
                 source_file=event['file'],
                 line_number=event['line'],
-                )
+            )
 
     def catalog(self, node=None):
         """Get the most recent catalog for a given node"""

--- a/pypuppetdb/api/v4.py
+++ b/pypuppetdb/api/v4.py
@@ -253,7 +253,7 @@ class API(BaseAPI):
 
     def server_time(self):
         """Get the current time of the clock on the PuppetDB server"""
-        return self._query('server-time')['server-time']
+        return self._query('server-time')['server_time']
 
     def current_version(self):
         """Get version information about the running PuppetDB server"""
@@ -262,8 +262,8 @@ class API(BaseAPI):
     def catalog(self, node):
         """Get the most recent catalog for a given node"""
         c = self._query('catalogs', path=node)
-        return Catalog(c['data']['name'],
+        return Catalog(c['data']['certname'],
                        c['data']['edges'],
                        c['data']['resources'],
                        c['data']['version'],
-                       c['data']['transaction-uuid'])
+                       c['data']['transaction_uuid'])

--- a/pypuppetdb/types.py
+++ b/pypuppetdb/types.py
@@ -410,7 +410,7 @@ class Catalog(object):
                        catalog's certname
     """
     def __init__(self, node, edges, resources, version, transaction_uuid,
-                 environment):
+                 environment=None):
 
         self.node = node
         self.version = version
@@ -423,11 +423,13 @@ class Catalog(object):
                 resource['file'] = None
             if 'line' not in resource:
                 resource['line'] = None
-            identifier = resource['type']+'['+resource['title']+']'
+            identifier = resource['type'] + '[' + resource['title'] + ']'
             res = Resource(node=node, name=resource['title'],
                            type_=resource['type'], tags=resource['tags'],
-                           exported=resource['exported'], sourcefile=resource['file'],
-                           sourceline=resource['line'], parameters=resource['parameters'],
+                           exported=resource['exported'],
+                           sourcefile=resource['file'],
+                           sourceline=resource['line'],
+                           parameters=resource['parameters'],
                            environment=self.environment)
             self.resources[identifier] = res
 

--- a/pypuppetdb/types.py
+++ b/pypuppetdb/types.py
@@ -124,8 +124,8 @@ class Report(object):
             run.
     """
     def __init__(self, node, hash_, start, end, received, version,
-                 format_, agent_version, transaction, status, 
-                 events_={}, metrics_={}, logs_={}, environment='production', 
+                 format_, agent_version, transaction, status=None,
+                 events_={}, metrics_={}, logs_={}, environment=None,
                  noop=False):
 
         self.node = node
@@ -169,7 +169,7 @@ class Fact(object):
     :ivar value: :obj:`string` holding the fact's value.
     :ivar environment: :obj:`string` holding the fact's environment
     """
-    def __init__(self, node, name, value, environment):
+    def __init__(self, node, name, value, environment=None):
         self.node = node
         self.name = name
         self.value = value
@@ -217,7 +217,7 @@ class Resource(object):
         with this resource.
     """
     def __init__(self, node, name, type_, tags, exported, sourcefile,
-                 sourceline, environment, parameters={}):
+                 sourceline, environment=None, parameters={}):
         self.node = node
         self.name = name
         self.type_ = type_
@@ -285,23 +285,27 @@ class Node(object):
             compiled or `None`.
     :ivar facts_timestamp: :obj:`datetime.datetime` last time when facts were\
             collected or `None`.
-    :ivar report_environment: :obj:`string` the environment of the last received\
-            report for this node.
+    :ivar report_environment: :obj:`string` the environment of the last\
+            received report for this node.
     :ivar catalog_environment: :obj:`string` the environment of the last\
             received catalog for this node.
-    :ivar facts_environment: :obj:`string` the environemtn of the last received\
-            fact set for this node.
+    :ivar facts_environment: :obj:`string` the environemtn of the last\
+            received fact set for this node.
     """
-    def __init__(self, api, name, deactivated=None, report_timestamp=None,
-                 catalog_timestamp=None, facts_timestamp=None,
-                 status=None, events=None, unreported_time=None,
-                 report_environment='production', catalog_environment='production',
+    def __init__(self, api, name, deactivated=None, expired=None,
+                 report_timestamp=None, catalog_timestamp=None,
+                 facts_timestamp=None, status=None, events=None,
+                 unreported_time=None, report_environment='production',
+                 catalog_environment='production',
                  facts_environment='production'):
         self.name = name
         self.status = status
         self.events = events
         self.unreported_time = unreported_time
         self.report_timestamp = report_timestamp
+        self.catalog_timestamp = catalog_timestamp
+        self.facts_timestamp = facts_timestamp
+        self.report_environment = report_environment
         self.catalog_environment = catalog_environment
         self.facts_environment = facts_environment
 
@@ -309,6 +313,10 @@ class Node(object):
             self.deactivated = json_to_datetime(deactivated)
         else:
             self.deactivated = False
+        if expired is not None:
+            self.expired = json_to_datetime(expired)
+        else:
+            self.expired = False
         if report_timestamp is not None:
             self.report_timestamp = json_to_datetime(report_timestamp)
         else:
@@ -409,7 +417,7 @@ class Catalog(object):
                 resource['file'] = None
             if 'line' not in resource:
                 resource['line'] = None
-            identifier = resource['type']+'['+resource['title']+']'
+            identifier = resource['type'] + '[' + resource['title'] + ']'
             res = Resource(node, resource['title'],
                            resource['type'], resource['tags'],
                            resource['exported'], resource['file'],

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -26,6 +26,10 @@ class TestBaseAPIVersion(object):
         v3 = pypuppetdb.api.BaseAPI(3)
         assert v3.api_version == 'v3'
 
+    def test_init_v4_defaults(self):
+        v4 = pypuppetdb.api.BaseAPI(4)
+        assert v4.api_version == 'v4'
+
     def test_init_invalid_version(self):
         with pytest.raises(pypuppetdb.errors.UnsupportedVersionError):
             vderp = pypuppetdb.api.BaseAPI(10000)
@@ -215,8 +219,10 @@ class TesteAPIQuery(object):
         baseapi.password = 'password123'
         baseapi._query('nodes')
         assert httpretty.last_request().path == '/v3/nodes'
+        encoded_cred = 'puppetdb:password123'.encode('utf-8')
+        bs_authheader = base64.b64encode(encoded_cred).decode('utf-8')
         assert httpretty.last_request().headers['Authorization'] == \
-            'Basic {0}'.format(base64.b64encode('puppetdb:password123'))
+            'Basic {0}'.format(bs_authheader)
         httpretty.disable()
         httpretty.reset()
 
@@ -334,3 +340,8 @@ class TestAPIMethods(object):
         assert httpretty.last_request().path == '/v3/metrics/mbean/test'
         httpretty.disable()
         httpretty.reset()
+
+    def test_normalize_resource_type(self, baseapi):
+        assert baseapi._normalize_resource_type('sysctl::value') == \
+            'Sysctl::Value'
+        assert baseapi._normalize_resource_type('user') == 'User'

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -294,7 +294,7 @@ class TesteAPIQuery(object):
         stub_request('http://localhost:8080/v3/nodes')
         baseapi._query('nodes', count_filter=1)
         assert httpretty.last_request().querystring == {
-            'count-filter': ['1']}
+            'counts-filter': ['1']}
         httpretty.disable()
         httpretty.reset()
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -15,3 +15,8 @@ def test_connect_api_v2():
 def test_connect_api_v3():
     puppetdb = pypuppetdb.connect(api_version=3)
     assert puppetdb.version == 'v3'
+
+
+def test_connect_api_v4():
+    puppetdb = pypuppetdb.connect(api_version=4)
+    assert puppetdb.version == 'v4'

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -20,6 +20,7 @@ class TestNode(object):
 
         assert node.name == 'node'
         assert node.deactivated is False
+        assert node.expired is False
         assert node.report_timestamp is not None
         assert node.facts_timestamp is not None
         assert node.catalog_timestamp is not None
@@ -37,6 +38,7 @@ class TestNode(object):
 
         assert node.name == 'node'
         assert node.deactivated is False
+        assert node.expired is False
         assert node.report_timestamp is not None
         assert node.facts_timestamp is not None
         assert node.catalog_timestamp is not None
@@ -46,15 +48,56 @@ class TestNode(object):
         assert unicode(node) == unicode('node')
         assert repr(node) == str('<Node: node>')
 
+    def test_apiv4_without_status(self):
+        node = Node('_', 'node',
+                    report_environment='development',
+                    catalog_environment='development',
+                    facts_environment='development',
+                    report_timestamp='2013-08-01T09:57:00.000Z',
+                    catalog_timestamp='2013-08-01T09:57:00.000Z',
+                    facts_timestamp='2013-08-01T09:57:00.000Z',)
+
+        assert node.name == 'node'
+        assert node.deactivated is False
+        assert node.expired is False
+        assert node.report_environment == 'development'
+        assert node.catalog_environment == 'development'
+        assert node.facts_environment == 'development'
+        assert node.report_timestamp is not None
+        assert node.facts_timestamp is not None
+        assert node.catalog_timestamp is not None
+        assert str(node) == str('node')
+        assert unicode(node) == unicode('node')
+        assert repr(node) == str('<Node: node>')
+
+    def test_deactivated(self):
+        node = Node('_', 'node',
+                    deactivated='2013-08-01T09:57:00.000Z',)
+        assert node.name == 'node'
+        assert node.deactivated is not False
+        assert str(node) == str('node')
+        assert unicode(node) == unicode('node')
+        assert repr(node) == str('<Node: node>')
+
+    def test_expired(self):
+        node = Node('_', 'node',
+                    expired='2013-08-01T09:57:00.000Z',)
+        assert node.name == 'node'
+        assert node.expired is not False
+        assert str(node) == str('node')
+        assert unicode(node) == unicode('node')
+        assert repr(node) == str('<Node: node>')
+
 
 class TestFact(object):
     """Test the Fact object."""
     def test_fact(self):
-        fact = Fact('node', 'osfamily', 'Debian')
+        fact = Fact('node', 'osfamily', 'Debian', 'production')
 
         assert fact.node == 'node'
         assert fact.name == 'osfamily'
         assert fact.value == 'Debian'
+        assert fact.environment == 'production'
         assert str(fact) == str('osfamily/node')
         assert unicode(fact) == unicode('osfamily/node')
         assert repr(fact) == str('Fact: osfamily/node')
@@ -66,7 +109,7 @@ class TestResource(object):
     def test_resource(self):
         resource = Resource('node', '/etc/ssh/sshd_config', 'file',
                             ['class', 'ssh'], False, '/ssh/manifests/init.pp',
-                            15, parameters={
+                            15, 'production', parameters={
                                 'ensure': 'present',
                                 'owner': 'root',
                                 'group': 'root',
@@ -80,6 +123,7 @@ class TestResource(object):
         assert resource.exported is False
         assert resource.sourcefile == '/ssh/manifests/init.pp'
         assert resource.sourceline == 15
+        assert resource.environment == 'production'
         assert resource.parameters['ensure'] == 'present'
         assert resource.parameters['owner'] == 'root'
         assert resource.parameters['group'] == 'root'
@@ -98,7 +142,8 @@ class TestReport(object):
                         '2013-08-01T10:57:00.000Z',
                         '2013-08-01T10:58:00.000Z',
                         '1351535883', 3, '3.2.1',
-                        'af9f16e3-75f6-4f90-acc6-f83d6524a6f3')
+                        'af9f16e3-75f6-4f90-acc6-f83d6524a6f3',
+                        status='success')
 
         assert report.node == 'node1.puppet.board'
         assert report.hash_ == 'hash#'
@@ -110,6 +155,7 @@ class TestReport(object):
         assert report.agent_version == '3.2.1'
         assert report.run_time == report.end - report.start
         assert report.transaction == 'af9f16e3-75f6-4f90-acc6-f83d6524a6f3'
+        assert report.status == 'success'
         assert str(report) == str('hash#')
         assert unicode(report) == unicode('hash#')
         assert repr(report) == str('Report: hash#')
@@ -174,11 +220,13 @@ class TestEdge(object):
     def test_edge(self):
         resource_a = Resource('node', '/etc/ssh/sshd_config', 'file',
                               ['class', 'ssh'], False,
-                              '/ssh/manifests/init.pp', 15, parameters={})
+                              '/ssh/manifests/init.pp', 15, 'production',
+                              parameters={})
 
         resource_b = Resource('node', 'sshd', 'service',
                               ['class', 'ssh'], False,
-                              '/ssh/manifests/init.pp', 30, parameters={})
+                              '/ssh/manifests/init.pp', 30, 'production',
+                              parameters={})
 
         edge = Edge(resource_a, resource_b, 'notify')
 


### PR DESCRIPTION
Hi,

Looks like you did a great job to support puppetdb3 and API v4 ! Here's some tweaks to keep backward compatibility between puppetdb versions. 
I should make more tests in the next few days.

Travis is building again, but I still have issues with Coveralls.
https://travis-ci.org/colmat/pypuppetdb

Let me know if I can do anything else to help,
Matt.